### PR TITLE
Fixed Moduled Nemesis and Enigma

### DIFF
--- a/src/lib/enigma.cc
+++ b/src/lib/enigma.cc
@@ -35,6 +35,9 @@
 
 using namespace std;
 
+template<>
+size_t moduled_enigma::PadMaskBits = 1u;
+
 typedef ibitstream<unsigned short, true> EniIBitstream;
 typedef obitstream<unsigned short> EniOBitstream;
 

--- a/src/lib/nemesis.cc
+++ b/src/lib/nemesis.cc
@@ -36,6 +36,9 @@
 
 using namespace std;
 
+template<>
+size_t moduled_nemesis::PadMaskBits = 1u;
+
 // This represents a nibble run of up to 7 repetitions of the starting nibble.
 class nibble_run {
 private:


### PR DESCRIPTION
I was getting errors about PadMaskBits not being defined. This was with Visual Studio 2017 RC's compiler.