### PR TITLE
Support for moduled Comper in "compcmp"; a few minor fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Makefile.in
 /src/tools/enicmp
 /src/tools/koscmp
 /src/tools/kosplus
+/src/tools/lzkn1cmp
 /src/tools/mkoscmp
 /src/tools/nemcmp
 /src/tools/saxcmp

--- a/src/tools/kosplus.cc
+++ b/src/tools/kosplus.cc
@@ -35,7 +35,7 @@ using std::stringstream;
 
 static void usage(char* prog) {
     cerr << "Usage: " << prog
-         << " [-c|--crunch|-x|--extract=[{pointer}]] [-m|--moduled=[{size}]] "
+         << " [-c|--crunch|-x|--extract=[{pointer}]] [-m|--moduled] "
             "{input_filename} {output_filename}"
          << endl;
     cerr << endl;


### PR DESCRIPTION
This PR introduces support for "-m" argument in "compcmp" tools, which makes use of framework's ability to encode/decode moduled data archives.

Additional source code fixes include the following:
- Included "/src/tools/lzkn1cmp" in .gitignore;
- Fixed incorrect arguments description in "kosplus" tool.