### PR TITLE
Fix Rocket decompression and make this compile with Visual Studio 2019.

### DIFF
--- a/include/mdcomp/bigendian_io.hh
+++ b/include/mdcomp/bigendian_io.hh
@@ -299,15 +299,15 @@ namespace detail {
         template <typename T>
         static inline void Read(std::istream& in, T& val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
-            in.read(std::begin(buffer), sizeof(T));
-            std::memcpy(&val, std::cbegin(buffer), sizeof(T));
+            in.read(std::data(buffer), sizeof(T));
+            std::memcpy(&val, std::data(buffer), sizeof(T));
         }
 
         template <typename T>
         static inline void Read(std::streambuf& in, T& val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
             in.sgetn(std::begin(buffer), sizeof(T));
-            std::memcpy(&val, std::cbegin(buffer), sizeof(T));
+            std::memcpy(&val, std::data(buffer), sizeof(T));
         }
 
         template <typename Iter, typename T>
@@ -321,15 +321,15 @@ namespace detail {
         template <typename T>
         static inline void Write(std::ostream& out, T val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
-            std::memcpy(std::begin(buffer), &val, sizeof(T));
-            out.write(std::cbegin(buffer), sizeof(T));
+            std::memcpy(std::data(buffer), &val, sizeof(T));
+            out.write(std::data(buffer), sizeof(T));
         }
 
         template <typename T>
         static inline void Write(std::streambuf& out, T val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
             std::memcpy(std::begin(buffer), &val, sizeof(T));
-            out.sputn(std::cbegin(buffer), sizeof(T));
+            out.sputn(std::data(buffer), sizeof(T));
         }
 
         template <typename Cont, typename T>

--- a/include/mdcomp/bigendian_io.hh
+++ b/include/mdcomp/bigendian_io.hh
@@ -299,15 +299,15 @@ namespace detail {
         template <typename T>
         static inline void Read(std::istream& in, T& val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
-            in.read(std::data(buffer), sizeof(T));
-            std::memcpy(&val, std::data(buffer), sizeof(T));
+            in.read(buffer.data(), sizeof(T));
+            std::memcpy(&val, buffer.data(), sizeof(T));
         }
 
         template <typename T>
         static inline void Read(std::streambuf& in, T& val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
             in.sgetn(std::begin(buffer), sizeof(T));
-            std::memcpy(&val, std::data(buffer), sizeof(T));
+            std::memcpy(&val, buffer.data(), sizeof(T));
         }
 
         template <typename Iter, typename T>
@@ -321,15 +321,15 @@ namespace detail {
         template <typename T>
         static inline void Write(std::ostream& out, T val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
-            std::memcpy(std::data(buffer), &val, sizeof(T));
-            out.write(std::data(buffer), sizeof(T));
+            std::memcpy(buffer.data(), &val, sizeof(T));
+            out.write(buffer.data(), sizeof(T));
         }
 
         template <typename T>
         static inline void Write(std::streambuf& out, T val) noexcept {
             alignas(alignof(T)) std::array<char, sizeof(T)> buffer;
             std::memcpy(std::begin(buffer), &val, sizeof(T));
-            out.sputn(std::data(buffer), sizeof(T));
+            out.sputn(buffer.data(), sizeof(T));
         }
 
         template <typename Cont, typename T>

--- a/include/mdcomp/lzss.hh
+++ b/include/mdcomp/lzss.hh
@@ -20,6 +20,7 @@
 #define LIB_LZSS_HH
 
 #include "ignore_unused_variable_warning.hh"
+#include "unreachable.hh"
 
 #include <mdcomp/bigendian_io.hh>
 #include <mdcomp/bitstream.hh>
@@ -31,14 +32,6 @@
 #include <list>
 #include <string>
 #include <vector>
-
-#ifdef _MSC_VER
-#    ifndef __clang__
-[[noreturn]] inline void __builtin_unreachable() {
-    __assume(false);
-}
-#    endif
-#endif
 
 /*
  * Class representing an edge in the LZSS-compression graph. An edge (u, v)

--- a/include/mdcomp/unreachable.hh
+++ b/include/mdcomp/unreachable.hh
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Flamewing 2016 <flamewing.sonic@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIB_UNREACHABLE_HH
+#define LIB_UNREACHABLE_HH
+
+#ifdef _MSC_VER
+#    ifndef __clang__
+[[noreturn]] inline void __builtin_unreachable() {
+    __assume(false);
+}
+#    endif
+#endif
+
+#endif    // LIB_UNREACHABLE_HH

--- a/src/lib/enigma.cc
+++ b/src/lib/enigma.cc
@@ -40,6 +40,7 @@
 #include <mdcomp/bitstream.hh>
 #include <mdcomp/enigma.hh>
 #include <mdcomp/ignore_unused_variable_warning.hh>
+#include <mdcomp/unreachable.hh>
 
 using std::array;
 using std::forward;

--- a/src/lib/rocket.cc
+++ b/src/lib/rocket.cc
@@ -127,11 +127,11 @@ public:
         using RockIStream = LZSSIStream<RocketAdaptor>;
         using diff_t      = make_signed_t<size_t>;
 
-        in.ignore(2);
-        size_t const Size = BigEndian::Read2(in) + 4;
+        size_t const OutSize = BigEndian::Read2(in);
+        size_t const InSize = BigEndian::Read2(in) + 4;
         RockIStream  src(in);
 
-        while (in.good() && size_t(in.tellg()) < Size) {
+        while (in.good() && size_t(in.tellg()) < InSize && size_t(Dst.tellp()) < OutSize) {
             if (src.descbit() != 0U) {
                 // Symbolwise match.
                 uint8_t const Byte = Read1(in);


### PR DESCRIPTION
I updated the copy of this in [the shell extension](https://github.com/MainMemory/FW-KENSC-ShellExt). It compiles fine with MSYS2, but Visual Studio gets caught on some mistakes. This fixes them to get it working.

The Rocket decompression wasn't stopping at the last decompressed byte, advancing on until it exhausted all of the descriptor bits, causing garbage bytes to be produced past the end of the decompressed data.